### PR TITLE
add Counter to display nr of tabs and panes per session

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ shared_except "locked" {
     bind "Ctrl {char}" {
         LaunchOrFocusPlugin "file:~/.config/zellij/plugins/zellij-favs.wasm" {
             floating true
+            display_tab_panes true
             cache_dir "/path/to/cache/file"
         }
     }
@@ -69,6 +70,7 @@ shared_except "locked" {
 bind "Ctrl {char}" {
     LaunchOrFocusPlugin "https://github.com/JoseMM2002/zellij-favs/releases/download/v1.0.1/zellij-favs.wasm" {
         floating true
+        display_tab_panes true
         cache_dir "/path/to/cache/file"
     }
 }

--- a/src/favs.rs
+++ b/src/favs.rs
@@ -22,6 +22,7 @@ pub struct Favs {
     pub filter: Option<String>,
     pub has_loaded: bool,
     pub cache_dir: String,
+    pub display_tab_panes: bool,
 }
 
 impl Default for Favs {
@@ -35,6 +36,7 @@ impl Default for Favs {
             filter: None,
             flush_sessions: vec![],
             cache_dir: String::from("~/.cache/favs.json"),
+            display_tab_panes: false,
         }
     }
 }
@@ -186,13 +188,19 @@ impl Favs {
             } else {
                 "".to_string()
             };
-            let counts = format!(" ({} tabs, {} panes)", session.tabs, session.panes);
+
+            let counters = if self.display_tab_panes {
+                format!(" ({} tabs, {} panes)", session.tabs, session.panes)
+            } else {
+                "".to_string()
+            };
+
             let text = if self.mode == FavMode::NavigateFavs && selected_idx == i {
                 let selected = format!(
                     "> {}{}{}",
                     session.name.clone().underline(),
                     assigned_number,
-                    counts.dimmed()
+                    counters.dimmed()
                 );
                 Text::new(selected)
             } else if self.mode == FavMode::AssignNumber
@@ -207,7 +215,7 @@ impl Favs {
                     "{}{}{}",
                     session.name.clone(),
                     assigned_number,
-                    counts.dimmed()
+                    counters.dimmed()
                 ))
             };
 
@@ -250,7 +258,13 @@ impl Favs {
             } else {
                 "".to_string()
             };
-            let counts = format!(" ({} tabs, {} panes)", session.tabs, session.panes);
+
+            let counts = if self.display_tab_panes {
+                format!(" ({} tabs, {} panes)", session.tabs, session.panes)
+            } else {
+                "".to_string()
+            };
+
             let text = if self.mode == FavMode::NavigateFlush && selected_idx == i {
                 let selected = format!(
                     "> {}{}{}",
@@ -316,6 +330,10 @@ impl ZellijPlugin for Favs {
         if let Some(cache_dir) = configuration.get("cache_dir") {
             self.cache_dir = cache_dir.to_string();
         }
+        if let Some(display_tab_panes) = configuration.get("display_tab_panes") {
+            self.display_tab_panes = matches!(display_tab_panes.trim(), "true" | "t" | "y" | "1");
+        }
+
         request_permission(&[
             PermissionType::ReadApplicationState,
             PermissionType::ChangeApplicationState,

--- a/src/favs.rs
+++ b/src/favs.rs
@@ -344,7 +344,12 @@ impl ZellijPlugin for Favs {
                         (
                             &s.name,
                             s.tabs.len(),
-                            s.panes.panes.values().map(|v| v.len()).sum(),
+                            s.panes
+                                .panes
+                                .values()
+                                .flat_map(|v| v.iter())
+                                .filter(|pane| !(pane.is_plugin))
+                                .count(),
                             true,
                         )
                     })

--- a/src/favs_mode.rs
+++ b/src/favs_mode.rs
@@ -30,6 +30,7 @@ impl FavMode {
                 ("<Space>", "Move session to Flush/Favorites"),
                 ("<Tab>", "Navigate Flush/Favorites items"),
                 ("a", "Add quick access number"),
+                ("t", "Toggle tabs & panes counter"),
                 ("↑k | ↓j", "Move cursor"),
                 ("/", "Filter"),
                 ("?", "Help"),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,6 +14,8 @@ pub struct FavSessionInfo {
     pub name: String,
     pub is_active: bool,
     pub assigned_number: Option<u8>,
+    pub tabs: usize,
+    pub panes: usize,
 }
 
 #[derive(Clone, Serialize, Deserialize, Copy, Debug)]

--- a/src/navigate.rs
+++ b/src/navigate.rs
@@ -129,6 +129,8 @@ pub fn match_navigation_keys(ctx: &mut Favs, key: &BareKey) -> bool {
         BareKey::Char('?') => {
             ctx.mode = FavMode::Help;
         }
+        BareKey::Char('t') => ctx.display_tab_panes = !ctx.display_tab_panes,
+
         BareKey::Char(c) if c.is_ascii_digit() => {
             let digit = c.to_digit(10).unwrap() as u8;
             for session in ctx.fav_sessions.iter() {


### PR DESCRIPTION
A PR that adds tabs and panes counter for each session, mimicking the default session-manager. 

It's not as advanced as the session-manager, with dropdowns and a detailed view, this is only the "top-level" information. 

Plugin tabs are filtered out, so for example zjstatus statusbar or other plugins that are opened inside a session will not be shown. 

<img width="759" height="448" alt="Screenshot 2025-10-03 at 19 07 36" src="https://github.com/user-attachments/assets/1f7c6f71-e88e-4489-bd03-8cb6289abbda" />


The counters for tabs and panes will also be saved to the cache file, so for the data in the picture, the case file looks like this: 

```
{
  "favs": [
    {
      "name": "Nix-config",
      "is_active": true,
      "assigned_number": 1,
      "tabs": 2,
      "panes": 3
    },
    {
      "name": "Zellij-fav",
      "is_active": true,
      "assigned_number": 2,
      "tabs": 1,
      "panes": 1
    }
  ],
  "flush": [
    {
      "name": "kind-cuckoo",
      "is_active": true,
      "assigned_number": null,
      "tabs": 1,
      "panes": 1
    }
  ]
}

```


A future improvment could be to determine the currently active session, and somehow indicate between active/inactive sessions ( they will show up with 0 tabs 0 panes atm ), but this could be a future PR, to keep it focused.